### PR TITLE
store theme created post types and taxonomies in WP options table

### DIFF
--- a/Post_Type/Base_Post_Type.php
+++ b/Post_Type/Base_Post_Type.php
@@ -24,10 +24,10 @@ abstract class Base_Post_Type {
 
         self::$post_types[ $class ] = $self;
 
-        // Store a list of theme declared post types in a WP option
-        $theme_post_types = get_option('theme_post_types', []);
-        $theme_post_types[] = self::post_type();
-        update_option('theme_post_types', array_unique($theme_post_types), false);
+        // Store a list of post types created by Benchpress
+        $benchpress_post_types = get_option('benchpress_post_types', []);
+        $benchpress_post_types[] = self::post_type();
+        update_option('benchpress_post_types', array_unique($benchpress_post_types), false);
 
         add_action( 'init', [ $self, '_register_post_type' ] );
         add_filter( 'post_updated_messages', [ $self, '_post_updated_messages_handler' ] );

--- a/Post_Type/Base_Post_Type.php
+++ b/Post_Type/Base_Post_Type.php
@@ -24,6 +24,11 @@ abstract class Base_Post_Type {
 
         self::$post_types[ $class ] = $self;
 
+        // Store a list of theme declared post types in a WP option
+        $theme_post_types = get_option('theme_post_types', []);
+        $theme_post_types[] = self::post_type();
+        update_option('theme_post_types', array_unique($theme_post_types), false);
+
         add_action( 'init', [ $self, '_register_post_type' ] );
         add_filter( 'post_updated_messages', [ $self, '_post_updated_messages_handler' ] );
     }

--- a/Post_Type/Base_Post_Type.php
+++ b/Post_Type/Base_Post_Type.php
@@ -24,11 +24,6 @@ abstract class Base_Post_Type {
 
         self::$post_types[ $class ] = $self;
 
-        // Store a list of post types created by Benchpress
-        $benchpress_post_types = get_option('benchpress_post_types', []);
-        $benchpress_post_types[] = self::post_type();
-        update_option('benchpress_post_types', array_unique($benchpress_post_types), false);
-
         add_action( 'init', [ $self, '_register_post_type' ] );
         add_filter( 'post_updated_messages', [ $self, '_post_updated_messages_handler' ] );
     }
@@ -58,7 +53,8 @@ abstract class Base_Post_Type {
                 $this->get_text_domain()
             ),
             'public' => true,
-            'taxonomies' => $this->get_taxonomies()
+            'taxonomies' => $this->get_taxonomies(),
+            'bencpress_post_type' => true,
         ];
     }
 

--- a/Taxonomy/Base_Taxonomy.php
+++ b/Taxonomy/Base_Taxonomy.php
@@ -24,10 +24,10 @@ abstract class Base_Taxonomy {
 
         self::$taxonomies[ $class ] = $self;
 
-        // Store a list of theme declared taxonomies in a WP option
-        $theme_taxonomies = get_option('theme_taxonomies', []);
-        $theme_taxonomies[] = self::taxonomy();
-        update_option('theme_taxonomies', array_unique($theme_taxonomies), false);
+        // Store a list of taxonomies created by Benchpress
+        $benchpress_taxonomies = get_option('benchpress_taxonomies', []);
+        $benchpress_taxonomies[] = self::taxonomy();
+        update_option('benchpress_taxonomies', array_unique($benchpress_taxonomies), false);
 
         add_action( 'init', [ $self, '_register_taxonomy' ] );
         add_filter( 'term_updated_messages', [ $self, '_term_updated_messages_handler' ] );

--- a/Taxonomy/Base_Taxonomy.php
+++ b/Taxonomy/Base_Taxonomy.php
@@ -24,11 +24,6 @@ abstract class Base_Taxonomy {
 
         self::$taxonomies[ $class ] = $self;
 
-        // Store a list of taxonomies created by Benchpress
-        $benchpress_taxonomies = get_option('benchpress_taxonomies', []);
-        $benchpress_taxonomies[] = self::taxonomy();
-        update_option('benchpress_taxonomies', array_unique($benchpress_taxonomies), false);
-
         add_action( 'init', [ $self, '_register_taxonomy' ] );
         add_filter( 'term_updated_messages', [ $self, '_term_updated_messages_handler' ] );
     }
@@ -50,7 +45,8 @@ abstract class Base_Taxonomy {
                 $this->get_singular_name(), 
                 $this->get_plural_name(), 
                 $this->get_text_domain()
-            )
+            ),
+            'benchpress_taxonomy' => true,
         ];
     }
 

--- a/Taxonomy/Base_Taxonomy.php
+++ b/Taxonomy/Base_Taxonomy.php
@@ -24,6 +24,11 @@ abstract class Base_Taxonomy {
 
         self::$taxonomies[ $class ] = $self;
 
+        // Store a list of theme declared taxonomies in a WP option
+        $theme_taxonomies = get_option('theme_taxonomies', []);
+        $theme_taxonomies[] = self::taxonomy();
+        update_option('theme_taxonomies', array_unique($theme_taxonomies), false);
+
         add_action( 'init', [ $self, '_register_taxonomy' ] );
         add_filter( 'term_updated_messages', [ $self, '_term_updated_messages_handler' ] );
     }


### PR DESCRIPTION
Updates Base_Taxonomy and Base_Post_Type classes to store a list of the created post_types and taxonomies in the WP options table.

This seemed like the least complicated way to store the list of post types and taxonomies created by a theme in a place where they are easily accessible.

I need them specifically for the work I'm doing on automatically generating archive pages for post types and taxonomies.