### PR TITLE
Fix for error thrown when an action has no arguments (php 8)

### DIFF
--- a/Hooks/Base_Hook.php
+++ b/Hooks/Base_Hook.php
@@ -57,7 +57,8 @@ abstract class Base_Hook {
             /**
              * If we should not invoke callback, return the first function arg which is necessary for filters.
              */
-            return func_get_arg(0);
+            $func_args = func_get_args();
+            return count($func_args) ? func_get_arg(0) : '';
         }
     }
 }

--- a/Hooks/Base_Hook.php
+++ b/Hooks/Base_Hook.php
@@ -58,7 +58,7 @@ abstract class Base_Hook {
              * If we should not invoke callback, return the first function arg which is necessary for filters.
              */
             $func_args = func_get_args();
-            return count($func_args) ? func_get_arg(0) : '';
+            return count($func_args) ? $func_args[0] : '';
         }
     }
 }


### PR DESCRIPTION
In the process of updating CCA for PHP 8.0, I received this error:

```
PHP Fatal error:  Uncaught ValueError: func_get_arg(): 
Argument #1 ($position) must be less than the number of the arguments 
passed to the currently executed function in 
/var/www/html/wp-content/themes/cca/vendor/expandtheroom/benchpress/Hooks/Base_Hook.php:64
```

This small tweak fixes the issue.