### PR TITLE
Update codebase for PHP 8 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea/
+vendor/

--- a/Hooks/Base_Action.php
+++ b/Hooks/Base_Action.php
@@ -12,17 +12,17 @@ namespace BenchPress\Hooks;
  */
 abstract class Base_Action extends Base_Hook {
 
-    final protected function add_hook( Base_Hook $instance ) {
+    final protected function add_hook() {
         add_action(
-            $instance->get_action(),
-            [ $instance, '__callback' ],
-            $instance->get_priority(),
-            $instance->get_arg_count()
+            $this->get_action(),
+            [ $this, '__callback' ],
+            $this->get_priority(),
+            $this->get_arg_count()
         );
     }
 
     final public static function remove() {
-        $class = get_called_class();
+        $class = static::class;
 
         if ( ! isset( static::$instances[ $class ] ) ) return;
 

--- a/Hooks/Base_Filter.php
+++ b/Hooks/Base_Filter.php
@@ -12,17 +12,17 @@ namespace BenchPress\Hooks;
  */
 abstract class Base_Filter extends Base_Hook {
 
-    final protected function add_hook( Base_Hook $instance ) {
+    final protected function add_hook() {
         add_filter(
-            $instance->get_filter(),
-            [ $instance, '__callback' ],
-            $instance->get_priority(),
-            $instance->get_arg_count()
+            $this->get_filter(),
+            [ $this, '__callback' ],
+            $this->get_priority(),
+            $this->get_arg_count()
         );
     }
 
     final public static function remove() {
-        $class = get_called_class();
+        $class = static::class;
 
         if ( ! isset( static::$instances[ $class ] ) ) return;
 

--- a/Hooks/Base_Hook.php
+++ b/Hooks/Base_Hook.php
@@ -10,7 +10,7 @@ abstract class Base_Hook {
      * Initializes the hook
      */
     public static function init() {
-        $called_class = get_called_class();
+        $called_class = static::class;
 
         if ( isset( static::$instances[ $called_class ] ) ) return;
 
@@ -18,10 +18,10 @@ abstract class Base_Hook {
 
         $instance = static::$instances[ $called_class ];
 
-        $instance->add_hook( $instance );
+        $instance->add_hook();
     }
 
-    protected abstract function add_hook( Base_Hook $instance );
+    abstract protected function add_hook();
 
     /**
      * @return int The number of arguments the hook callback accepts. Defaults to 1.
@@ -42,23 +42,22 @@ abstract class Base_Hook {
      * This function is used as the hook callback so we can determine if the actual
      * developer supplied callback should be invoked (depending on the return value of $this->should_run()).
      */
-    final public function __callback() {
+    final public function __callback( ...$args ) {
         // check if the user supplied callback should be invoked
-        if ( !method_exists( $this, 'should_run') || call_user_func_array( [ $this, 'should_run' ], func_get_args() ) ) {
+        if ( ! method_exists( $this, 'should_run' ) || $this->should_run( ...$args ) ) {
             /**
              * Return a call to callback which is necessary for filters. There is no harm in returning
              * the value for actions.
              */
-            if( !method_exists( $this, 'callback' ) )
-                throw new \Exception( 'Required method "callback is not defined.' );
+            if ( ! method_exists( $this, 'callback' ) )
+                throw new \Exception( 'Required method "callback" is not defined.' );
 
-            return call_user_func_array( [ $this, 'callback' ], func_get_args() );
+            return $this->callback( ...$args );
         } else {
             /**
              * If we should not invoke callback, return the first function arg which is necessary for filters.
              */
-            $func_args = func_get_args();
-            return count($func_args) ? $func_args[0] : '';
+            return count( $args ) ? $args[0] : '';
         }
     }
 }

--- a/Meta_Box/Meta_Box.php
+++ b/Meta_Box/Meta_Box.php
@@ -48,7 +48,7 @@ abstract class Meta_Box {
     /**
      * @return string The Post Type slug for which to add the meta box
      */
-    protected abstract function get_post_type();
+    abstract protected function get_post_type();
 
     final public function add_meta_boxes_handler( $post ) {
 
@@ -92,7 +92,7 @@ abstract class Meta_Box {
         return true;
     }
 
-    protected abstract function save_post_meta( $post_id );
+    abstract protected function save_post_meta( $post_id );
 
     protected function get_id() {
         $qualified_class_name = strtolower( get_class( $this ) );
@@ -100,7 +100,7 @@ abstract class Meta_Box {
         return basename( str_replace( '\\', '/', $qualified_class_name ) );
     }
 
-    protected abstract function get_title();
+    abstract protected function get_title( $post = null );
 
     /**
      * This method should be overridden to return the contents of the metabox.

--- a/Meta_Box/Meta_Box.php
+++ b/Meta_Box/Meta_Box.php
@@ -31,17 +31,17 @@ abstract class Meta_Box {
     public function register_hooks() {
         \add_action(
             'add_meta_boxes_' . $this->get_post_type(),
-            [ $this, 'add_meta_boxes_handler' ]
+            [$this, 'add_meta_boxes_handler']
         );
 
         \add_action(
             'save_post_' . $this->get_post_type(),
-            [ $this, 'save_post_handler' ]
+            [$this, 'save_post_handler']
         );
 
         \add_filter(
             'postbox_classes_' . $this->get_post_type() . '_' . $this->id,
-            [ $this, 'add_classes' ]
+            [$this, 'add_classes']
         );
     }
 
@@ -50,31 +50,31 @@ abstract class Meta_Box {
      */
     abstract protected function get_post_type();
 
-    final public function add_meta_boxes_handler( $post ) {
+    final public function add_meta_boxes_handler($post) {
 
         \add_meta_box(
             $this->id,
-            $this->get_title( $post ),
-            [ $this, 'get_content' ],
-            $this->get_screen( $post ),
-            $this->get_context( $post ),
-            $this->get_priority( $post ),
-            $this->get_callback_args( $post )
+            $this->get_title($post),
+            [$this, 'get_content'],
+            $this->get_screen($post),
+            $this->get_context($post),
+            $this->get_priority($post),
+            $this->get_callback_args($post)
         );
     }
 
-    final public function save_post_handler( $post ) {
+    final public function save_post_handler($post) {
         // allow sub class to prevent saving post meta
-        if ( ! $this->should_save_meta_data( $post ) ) return;
+        if (! $this->should_save_meta_data($post)) return;
 
         // return early if an autosave is happening
-        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
-        $this->save_post_meta( $post );
+        $this->save_post_meta($post);
     }
 
-    final public function add_classes( $classes ) {
-        return array_merge( $classes, $this->get_classes( $classes ) );
+    final public function add_classes($classes) {
+        return array_merge($classes, $this->get_classes($classes));
     }
 
     /**
@@ -84,23 +84,23 @@ abstract class Meta_Box {
      *
      * @return array
      */
-    protected function get_classes( $classes ) {
+    protected function get_classes($classes) {
         return $classes;
     }
 
-    protected function should_save_meta_data( $post ) {
+    protected function should_save_meta_data($post) {
         return true;
     }
 
-    abstract protected function save_post_meta( $post_id );
+    abstract protected function save_post_meta($post_id);
 
     protected function get_id() {
-        $qualified_class_name = strtolower( get_class( $this ) );
+        $qualified_class_name = strtolower(get_class($this));
 
-        return basename( str_replace( '\\', '/', $qualified_class_name ) );
+        return basename(str_replace('\\', '/', $qualified_class_name));
     }
 
-    abstract protected function get_title( $post = null );
+    abstract protected function get_title();
 
     /**
      * This method should be overridden to return the contents of the metabox.
@@ -111,19 +111,19 @@ abstract class Meta_Box {
         return '<h1>You need to return your own meta box content</h1>';
     }
 
-    protected function get_screen( $post ) {
+    protected function get_screen($post) {
         return null;
     }
 
-    protected function get_context( $post ) {
+    protected function get_context($post) {
         return Meta_Box_Context::ADVANCED;
     }
 
-    protected function get_priority( $post ) {
+    protected function get_priority($post) {
         return Meta_Box_Priority::NORMAL;
     }
 
-    protected function get_callback_args( $post ) {
+    protected function get_callback_args($post) {
         return null;
     }
 }

--- a/Post_Type/Base_Post_Type.php
+++ b/Post_Type/Base_Post_Type.php
@@ -16,7 +16,7 @@ abstract class Base_Post_Type {
     private static $post_types = [];
 
     public static function init() {
-        $class = get_called_class();
+        $class = static::class;
 
         if ( isset( self::$post_types[ $class ] ) ) return;
 
@@ -81,17 +81,17 @@ abstract class Base_Post_Type {
     /**
      * Returns the post type slug.
      */
-    protected abstract function get_post_type();
+    abstract protected function get_post_type();
 
     /**
      * Returns the singular name for the post type. The name should be initial caps.
      */
-    protected abstract function get_singular_name();
+    abstract protected function get_singular_name();
 
     /**
      * Returns the plural name for the post type. The name should be initial caps.
      */
-    protected abstract function get_plural_name();
+    abstract protected function get_plural_name();
 
     /**
      * Returns the post type arguments array.
@@ -118,7 +118,7 @@ abstract class Base_Post_Type {
      * Returns the post type slug for the class.
      */
     public static function post_type() {
-        $class = get_called_class();
+        $class = static::class;
 
         return self::$post_types[ $class ]->get_post_type();
     }

--- a/Shortcode/Shortcode.php
+++ b/Shortcode/Shortcode.php
@@ -40,7 +40,7 @@ abstract class Shortcode {
     /**
      * @return string The shortcode name.
      */
-    protected abstract function get_name();
+    abstract protected function get_name();
 
     /**
      * Return an array of defaults for the shortcode. These defaults will be merged with the
@@ -59,5 +59,5 @@ abstract class Shortcode {
      * The $atts will contain the values provided when the shortcode is used combined with the
      * defaults returned by get_defaults().
      */
-    protected abstract function get_content( $atts, $content, $tag );
+    abstract protected function get_content( $atts, $content, $tag );
 }

--- a/Taxonomy/Base_Taxonomy.php
+++ b/Taxonomy/Base_Taxonomy.php
@@ -16,7 +16,7 @@ abstract class Base_Taxonomy {
     protected static $taxonomies = [];
 
     public static function init() {
-        $class = get_called_class();
+        $class = static::class;
 
         if ( isset( self::$taxonomies[ $class ] ) ) return;
 
@@ -68,22 +68,22 @@ abstract class Base_Taxonomy {
     /**
      * Returns the taxonomy name.
      */
-    protected abstract function get_taxonomy();
+    abstract protected function get_taxonomy();
 
     /**
      * Returns the post types that taxonomy should be applied to.
      */
-    protected abstract function get_post_types();
+    abstract protected function get_post_types();
 
     /**
      * Returns the singular name of the taxonomy. The name should be initial caps.
      */
-    protected abstract function get_singular_name();
+    abstract protected function get_singular_name();
 
     /**
      * Returns the plural name of the taxonomy. The name should be initial caps.
      */
-    protected abstract function get_plural_name();
+    abstract protected function get_plural_name();
 
     /**
      * Returns the text domain to use for translations for this taxonomy.
@@ -104,7 +104,7 @@ abstract class Base_Taxonomy {
      * @return string
      */
     public static function taxonomy () {
-        $class = get_called_class();
+        $class = static::class;
 
         return self::$taxonomies[ $class ]->get_taxonomy();
     }

--- a/Walkers/Custom_Nav_Menu_Walker.php
+++ b/Walkers/Custom_Nav_Menu_Walker.php
@@ -35,41 +35,41 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
         'link_classes' => []
     ];
 
-    public function __construct( $args ) {
-        $this->args = wp_parse_args( $args, $this->args );
+    public function __construct($args) {
+        $this->args = wp_parse_args($args, $this->args);
     }
 
-    public function start_lvl( &$output, $depth = 0, $args = [] ) {
-        $indent = str_repeat( "\t", $depth );
-        $classes = implode( ' ', $this->args['level_classes'] );
+    public function start_lvl(&$output, $depth = 0, $args = []) {
+        $indent = str_repeat("\t", $depth);
+        $classes = implode(' ', $this->args['level_classes']);
 
-        if ( empty( $this->args['level_el'] ) ) {
+        if (empty($this->args['level_el'])) {
             return;
         }
 
-        $output .= "\n$indent<{$this->args['level_el']} class=\"#{$classes}\">\n";
+        $output .= "\n$indent<{$this->args['level_el']} class=\"{$classes}\">\n";
     }
 
-    public function end_lvl( &$output, $depth = 0, $args = [] ) {
-        if ( empty( $this->args['level_el'] ) ) {
+    public function end_lvl(&$output, $depth = 0, $args = []) {
+        if (empty($this->args['level_el'])) {
             return;
         }
 
-        $indent = str_repeat( "\t", $depth );
+        $indent = str_repeat("\t", $depth);
         $output .= "$indent</{$this->args['level_el']}>\n";
     }
 
-    public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
-        $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+    public function start_el(&$output, $item, $depth = 0, $args = null, $id = 0) {
+        $indent = ($depth) ? str_repeat("\t", $depth) : '';
 
-        if ( $this->args['include_wp_classes'] ) {
-            $classes = empty( $item->classes ) ? array() : (array) $item->classes;
+        if ($this->args['include_wp_classes']) {
+            $classes = empty($item->classes) ? array() : (array) $item->classes;
             $classes[] = 'menu-item-' . $item->ID;
         } else {
             $classes = [];
         }
 
-        $classes = array_merge( $classes, $this->args['el_container_classes'] );
+        $classes = array_merge($classes, $this->args['el_container_classes']);
 
         /**
          * Filters the arguments for a single nav menu item.
@@ -80,7 +80,22 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param object $item  Menu item data object.
          * @param int    $depth Depth of menu item. Used for padding.
          */
-        $args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
+        $args = apply_filters('nav_menu_item_args', $args, $item, $depth);
+
+        if (!\is_object($args)) {
+            $args = (object) wp_parse_args(\is_array($args) ? $args : [], [
+                'before' => '',
+                'after' => '',
+                'link_before' => '',
+                'link_after' => '',
+            ]);
+        } else {
+            foreach (['before', 'after', 'link_before', 'link_after'] as $prop) {
+                if (!isset($args->$prop)) {
+                    $args->$prop = '';
+                }
+            }
+        }
 
         /**
          * Filters the CSS class(es) applied to a menu item's list item element.
@@ -93,8 +108,8 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param array  $args    An array of wp_nav_menu() arguments.
          * @param int    $depth   Depth of menu item. Used for padding.
          */
-        $class_names = implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
-        $class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+        $class_names = implode(' ', apply_filters('nav_menu_css_class', array_filter($classes), $item, $args, $depth));
+        $class_names = $class_names ? ' class="' . esc_attr($class_names) . '"' : '';
 
         /**
          * Filters the ID applied to a menu item's list item element.
@@ -107,25 +122,25 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param array  $args    An array of wp_nav_menu() arguments.
          * @param int    $depth   Depth of menu item. Used for padding.
          */
-        $id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args, $depth );
-        $id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+        $id = apply_filters('nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth);
+        $id = $id ? ' id="' . esc_attr($id) . '"' : '';
 
-        if ( ! $this->args['include_wp_classes'] ) {
+        if (!$this->args['include_wp_classes']) {
             $id = '';
         }
 
-        if ( ! empty( $this->args['el_container'] ) ) {
-            $output .= $indent . '<' . $this->args['el_container'] . ' '  . $id . $class_names .'>';
+        if (!empty($this->args['el_container'])) {
+            $output .= $indent . '<' . $this->args['el_container'] . ' ' . $id . $class_names . '>';
         }
 
         $atts = array();
-        $atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
-        $atts['target'] = ! empty( $item->target )     ? $item->target     : '';
-        $atts['rel']    = ! empty( $item->xfn )        ? $item->xfn        : '';
-        $atts['href']   = ! empty( $item->url )        ? $item->url        : '';
+        $atts['title'] = !empty($item->attr_title) ? $item->attr_title : '';
+        $atts['target'] = !empty($item->target) ? $item->target : '';
+        $atts['rel'] = !empty($item->xfn) ? $item->xfn : '';
+        $atts['href'] = !empty($item->url) ? $item->url : '';
 
-        if ( ! empty( $this->args['link_classes'] ) ) {
-            $atts['class'] = implode( ' ', $this->args['link_classes'] );
+        if (!empty($this->args['link_classes'])) {
+            $atts['class'] = implode(' ', $this->args['link_classes']);
         }
 
         /**
@@ -146,18 +161,18 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param array  $args  An array of wp_nav_menu() arguments.
          * @param int    $depth Depth of menu item. Used for padding.
          */
-        $atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+        $atts = apply_filters('nav_menu_link_attributes', $atts, $item, $args, $depth);
 
         $attributes = '';
-        foreach ( $atts as $attr => $value ) {
-            if ( ! empty( $value ) ) {
-                $value = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+        foreach ($atts as $attr => $value) {
+            if (!empty($value)) {
+                $value = ('href' === $attr) ? esc_url($value) : esc_attr($value);
                 $attributes .= ' ' . $attr . '="' . $value . '"';
             }
         }
 
         /** This filter is documented in wp-includes/post-template.php */
-        $title = apply_filters( 'the_title', $item->title, $item->ID );
+        $title = apply_filters('the_title', $item->title, $item->ID);
 
         /**
          * Filters a menu item's title.
@@ -169,10 +184,10 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param array  $args  An array of wp_nav_menu() arguments.
          * @param int    $depth Depth of menu item. Used for padding.
          */
-        $title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
+        $title = apply_filters('nav_menu_item_title', $title, $item, $args, $depth);
 
         $item_output = $args->before;
-        $item_output .= '<a'. $attributes .'>';
+        $item_output .= '<a' . $attributes . '>';
         $item_output .= $args->link_before . $title . $args->link_after;
         $item_output .= '</a>';
         $item_output .= $args->after;
@@ -191,11 +206,11 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param int    $depth       Depth of menu item. Used for padding.
          * @param array  $args        An array of wp_nav_menu() arguments.
          */
-        $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+        $output .= apply_filters('walker_nav_menu_start_el', $item_output, $item, $depth, $args);
     }
 
-    public function end_el( &$output, $item, $depth = 0, $args = null ) {
-        if ( ! empty( $this->args['el_container'] ) ) {
+    public function end_el(&$output, $item, $depth = 0, $args = null) {
+        if (!empty($this->args['el_container'])) {
             $output .= "</{$this->args['el_container']}>\n";
         }
     }

--- a/Walkers/Custom_Nav_Menu_Walker.php
+++ b/Walkers/Custom_Nav_Menu_Walker.php
@@ -40,42 +40,36 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
     }
 
     public function start_lvl( &$output, $depth = 0, $args = [] ) {
-        $args = wp_parse_args( $args, $this->args );
-
         $indent = str_repeat( "\t", $depth );
-        $classes = implode( ' ', $args['level_classes'] );
+        $classes = implode( ' ', $this->args['level_classes'] );
 
-        if ( empty( $args['level_el'] ) ) {
+        if ( empty( $this->args['level_el'] ) ) {
             return;
         }
 
-        $output .= "\n$indent<{$args['level_el']} class=\"#{$classes}\">\n";
+        $output .= "\n$indent<{$this->args['level_el']} class=\"#{$classes}\">\n";
     }
 
     public function end_lvl( &$output, $depth = 0, $args = [] ) {
-        $args = wp_parse_args( $args, $this->args );
-
-        if ( empty( $args['level_el'] ) ) {
+        if ( empty( $this->args['level_el'] ) ) {
             return;
         }
 
         $indent = str_repeat( "\t", $depth );
-        $output .= "$indent</{$args['level_el']}>\n";
+        $output .= "$indent</{$this->args['level_el']}>\n";
     }
 
-    public function start_el( &$output, $item, $depth = 0, $args = [], $id = 0 ) {
-        $args = wp_parse_args( $args, $this->args );
-
+    public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
         $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
 
-        if ( $args['include_wp_classes'] ) {
+        if ( $this->args['include_wp_classes'] ) {
             $classes = empty( $item->classes ) ? array() : (array) $item->classes;
             $classes[] = 'menu-item-' . $item->ID;
         } else {
             $classes = [];
         }
 
-        $classes = array_merge( $classes, $args['el_container_classes'] );
+        $classes = array_merge( $classes, $this->args['el_container_classes'] );
 
         /**
          * Filters the arguments for a single nav menu item.
@@ -99,7 +93,7 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
          * @param array  $args    An array of wp_nav_menu() arguments.
          * @param int    $depth   Depth of menu item. Used for padding.
          */
-        $class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
+        $class_names = implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
         $class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
         /**
@@ -116,12 +110,12 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
         $id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args, $depth );
         $id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
-        if ( ! $args['include_wp_classes'] ) {
+        if ( ! $this->args['include_wp_classes'] ) {
             $id = '';
         }
 
-        if ( ! empty( $args['el_container'] ) ) {
-            $output .= $indent . '<' . $args['el_container'] . ' '  . $id . $class_names .'>';
+        if ( ! empty( $this->args['el_container'] ) ) {
+            $output .= $indent . '<' . $this->args['el_container'] . ' '  . $id . $class_names .'>';
         }
 
         $atts = array();
@@ -130,8 +124,8 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
         $atts['rel']    = ! empty( $item->xfn )        ? $item->xfn        : '';
         $atts['href']   = ! empty( $item->url )        ? $item->url        : '';
 
-        if ( ! empty( $args['link_classes'] ) ) {
-            $atts['class']  = implode(' ', $args['link_classes'] );
+        if ( ! empty( $this->args['link_classes'] ) ) {
+            $atts['class'] = implode( ' ', $this->args['link_classes'] );
         }
 
         /**
@@ -200,11 +194,9 @@ class Custom_Nav_Menu_Walker extends \Walker_Nav_Menu {
         $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
     }
 
-    public function end_el( &$output, $item, $depth = 0, $args = [] ) {
-        $args = wp_parse_args( $args, $this->args );
-
-        if ( ! empty( $args['el_container'] ) ) {
-            $output .= "</{$args['el_container']}>\n";
+    public function end_el( &$output, $item, $depth = 0, $args = null ) {
+        if ( ! empty( $this->args['el_container'] ) ) {
+            $output .= "</{$this->args['el_container']}>\n";
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,21 @@
 {
-    "name": "expandtheroom/benchpress",
-    "description": "BenchPress is a WordPress library that helps you develop better WordPress themes. It combines a number of helper",
-    "type": "wordpress-library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Ryan Ogden",
-            "email": "ryan@expandtheroom.com"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "BenchPress\\": "./"
-        },
-        "files": [
-            "functions.php"
-        ]
+  "name": "expandtheroom/benchpress",
+  "description": "BenchPress is a WordPress library that helps you develop better WordPress themes. It combines a number of helper",
+  "type": "wordpress-library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Ryan Ogden",
+      "email": "ryan@expandtheroom.com"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "BenchPress\\": "./"
     },
-    "require": {}
+    "files": [
+      "functions.php"
+    ]
+  },
+  "require": {}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5ec8698daa63e78ac3167ddd412d3d69",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/functions.php
+++ b/functions.php
@@ -21,13 +21,14 @@ if ( ! function_exists( __NAMESPACE__ . '\get_partial' ) ) {
             $partial .= '.php';
         }
 
+        $partial_path_info = pathinfo( $partial );
+
         if ( file_exists( $partial ) ) {
             // First check if the file exists. This allows absolute paths to be provided.
             $template = $partial;
         } else {
             // If not, use locate template and first search in partials directory,
             // then fall back to default theme directory.
-            $partial_path_info = pathinfo( $partial );
             $template = locate_template( [
                 apply_filters( 'benchpress/partials_directory', 'partials' ) . '/' . $partial,
                 apply_filters( 'benchpress/partials_directory', 'partials' ) . '/' . $partial_path_info['dirname'] . '/' . $partial_path_info['filename'] . '/' . $partial_path_info['basename'],
@@ -77,7 +78,7 @@ if ( ! function_exists( __NAMESPACE__ . '\get_user_role' ) ) {
      *
      * @return string|bool Returns the user role if found, false otherwise.
      */
-    function get_user_role( \WP_User $user = null ) {
+    function get_user_role( ?\WP_User $user = null ) {
         $user = $user ? new \WP_User( $user ) : \wp_get_current_user();
 
         return $user->roles ? $user->roles[0] : false;


### PR DESCRIPTION
Replace get_called_class() with static::class, use variadic args instead of func_get_args(), modernize abstract method declarations, and remove redundant wp_parse_args() calls in the nav walker.

---

These changes were recommended by Claude Code when I requested that it review Benchpress for PHP 8 and WP 7 compatibility and best practices.

The changes are non-breaking. The shape of the interface doesn't change and it will still work on PHP 7.4